### PR TITLE
Added 'set_lk_max_objects 537000' to README, to handle block 277596

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ http://bitcoin.org/may15.html
 
 	cat /var/local/lib/bitcoin-qt/DB_CONFIG
 	set_lk_max_locks 537000
+	set_lk_max_objects 537000
 
 	cat /var/local/lib/bitcoin-qt-testnet/testnet3/DB_CONFIG
 	set_lk_max_locks 537000
+	set_lk_max_objects 537000


### PR DESCRIPTION
Since block 277595 blockexplorer is stuck, because bitcoind can't handle block 277596. This will fix it.
